### PR TITLE
fix: build debug version of the program

### DIFF
--- a/v2/webdriver/selenium/test/test.js
+++ b/v2/webdriver/selenium/test/test.js
@@ -31,7 +31,7 @@ before(async function () {
   this.timeout(120000);
 
   // ensure the program has been built
-  spawnSync("pnpm", ["tauri", "build", "--no-bundle"], {
+  spawnSync("pnpm", ["tauri", "build", "--debug", "--no-bundle"], {
     cwd: path.resolve(__dirname, "../../.."),
     stdio: "inherit",
     shell: true,


### PR DESCRIPTION
We need --debug flag as we are searching built tauri program from the target/debug/ path.
This already happens for webdriverio but not for selenium